### PR TITLE
Remove ConnectionManager as a separate process

### DIFF
--- a/lib/membrane_rtsp_plugin/source.ex
+++ b/lib/membrane_rtsp_plugin/source.ex
@@ -101,7 +101,7 @@ defmodule Membrane.RTSP.Source do
 
   @impl true
   def handle_setup(_ctx, state) do
-    state = ConnectionManager.initialize_connection(state)
+    state = ConnectionManager.establish_connection(state)
     {[spec: create_sources_spec(state)], state}
   end
 

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -62,7 +62,7 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
     Membrane.Logger.debug("ConnectionManager: Setting RTSP on play mode")
 
     RTSP.play_no_response(state.rtsp_session)
-    state
+    %{state | keep_alive_timer: start_keep_alive_timer(state)}
   end
 
   @spec keep_alive(State.t()) :: State.t()

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -31,8 +31,8 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
     RTSP.transfer_socket_control(rtsp_session, new_controller)
   end
 
-  @spec initialize_connection(State.t()) :: State.t()
-  def initialize_connection(state) do
+  @spec establish_connection(State.t()) :: State.t()
+  def establish_connection(state) do
     state =
       with {:ok, state} <- start_rtsp_connection(state),
            {:ok, state} <- get_rtsp_description(state),

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -1,12 +1,11 @@
 defmodule Membrane.RTSP.Source.ConnectionManager do
   @moduledoc false
 
-  use GenServer
-
   require Membrane.Logger
+  require Membrane.Pad
 
-  alias __MODULE__
   alias Membrane.RTSP
+  alias Membrane.RTSP.Source.State
 
   @content_type_header [{"accept", "application/sdp"}]
 
@@ -24,110 +23,61 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
           transport: track_transport()
         }
 
-  defmodule State do
-    @moduledoc false
-    @type t :: %__MODULE__{
-            stream_uri: binary(),
-            allowed_media_types: ConnectionManager.media_types(),
-            transport: RTSP.Source.transport(),
-            timeout: Membrane.Time.t(),
-            keep_alive_interval: Membrane.Time.t(),
-            parent_pid: pid(),
-            rtsp_session: RTSP.t() | nil,
-            tracks: [ConnectionManager.track()],
-            keep_alive_timer: reference()
-          }
-
-    @enforce_keys [
-      :stream_uri,
-      :allowed_media_types,
-      :transport,
-      :timeout,
-      :keep_alive_interval,
-      :parent_pid
-    ]
-    defstruct @enforce_keys ++
-                [
-                  rtsp_session: nil,
-                  tracks: [],
-                  keep_alive_timer: nil
-                ]
-  end
-
   @typep connection_establishment_phase_return() ::
            {:ok, State.t()} | {:error, reason :: term(), State.t()}
 
-  @spec start_link(connection_opts()) :: GenServer.on_start()
-  def start_link(options) do
-    GenServer.start_link(__MODULE__, Map.put(options, :parent_pid, self()))
+  @spec transfer_rtsp_socket_control(RTSP.t(), pid()) :: :ok
+  def transfer_rtsp_socket_control(rtsp_session, new_controller) do
+    RTSP.transfer_socket_control(rtsp_session, new_controller)
   end
 
-  @spec stop(pid()) :: :ok
-  def stop(server) do
-    GenServer.call(server, :stop)
-  end
-
-  @spec transfer_rtsp_socket_control(connection_manager :: pid(), new_controller :: pid()) :: :ok
-  def transfer_rtsp_socket_control(connection_manager, new_controller) do
-    GenServer.call(connection_manager, {:transfer_rtsp_socket_control, new_controller})
-  end
-
-  @impl true
-  def init(options) do
-    state = struct(State, options)
-    send(self(), :connect)
-    {:ok, state}
-  end
-
-  @impl true
-  def handle_info(:connect, state) do
+  @spec initialize_connection(State.t()) :: State.t()
+  def initialize_connection(state) do
     state =
       with {:ok, state} <- start_rtsp_connection(state),
            {:ok, state} <- get_rtsp_description(state),
-           {:ok, state} <- setup_rtsp_connection(state),
-           {:ok, state} <- prepare_source(state) do
+           {:ok, state} <- setup_rtsp_connection(state) do
         state
       else
         {:error, reason, state} -> handle_rtsp_error(reason, state)
       end
 
-    {:noreply, state}
+    state
   end
 
-  @impl true
-  def handle_info(:source_ready, state) do
-    state =
-      case play(state) do
-        {:ok, state} ->
-          %{state | keep_alive_timer: start_keep_alive_timer(state)}
+  @spec play(State.t()) :: State.t()
+  def play(%State{transport: {:udp, _, _}} = state) do
+    Membrane.Logger.debug("ConnectionManager: Setting RTSP on play mode")
 
-        {:error, reason, state} ->
-          handle_rtsp_error(reason, state)
-      end
+    case RTSP.play(state.rtsp_session) do
+      {:ok, %{status: 200}} ->
+        %{state | keep_alive_timer: start_keep_alive_timer(state)}
 
-    {:noreply, state}
+      _error ->
+        handle_rtsp_error(:play_rtsp_failed, state)
+    end
   end
 
-  @impl true
-  def handle_info(:keep_alive, state) do
-    {:noreply, keep_alive(state)}
+  def play(%State{transport: :tcp} = state) do
+    Membrane.Logger.debug("ConnectionManager: Setting RTSP on play mode")
+
+    RTSP.play_no_response(state.rtsp_session)
+    state
   end
 
-  @impl true
-  def handle_info(message, state) do
-    Membrane.Logger.warning("received unexpected message: #{inspect(message)}")
-    {:noreply, state}
-  end
+  @spec keep_alive(State.t()) :: State.t()
+  def keep_alive(state) do
+    Membrane.Logger.debug("Send GET_PARAMETER to keep session alive")
 
-  @impl true
-  def handle_call(:stop, _from, state) do
-    RTSP.close(state.rtsp_session)
-    {:stop, :normal, :ok, state}
-  end
+    case state.transport do
+      :tcp ->
+        RTSP.get_parameter_no_response(state.rtsp_session)
 
-  @impl true
-  def handle_call({:transfer_rtsp_socket_control, new_controller}, _from, state) do
-    {:reply, RTSP.transfer_socket_control(state.rtsp_session, new_controller), state}
+      {:udp, _port_range_start, _port_range_end} ->
+        {:ok, %{status: 200}} = RTSP.get_parameter(state.rtsp_session)
+    end
+
+    %{state | keep_alive_timer: start_keep_alive_timer(state)}
   end
 
   @spec start_rtsp_connection(State.t()) :: connection_establishment_phase_return()
@@ -173,45 +123,6 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
       {:ok, tracks} -> {:ok, %{state | tracks: tracks}}
       {:error, reason} -> {:error, reason, state}
     end
-  end
-
-  @spec prepare_source(State.t()) :: connection_establishment_phase_return()
-  defp prepare_source(state) do
-    notify_parent(%{rtsp_session: state.rtsp_session, tracks: state.tracks}, state)
-
-    {:ok, state}
-  end
-
-  @spec play(State.t()) :: connection_establishment_phase_return()
-  defp play(%{rtsp_session: rtsp_session, transport: {:udp, _, _}} = state) do
-    Membrane.Logger.debug("ConnectionManager: Setting RTSP on play mode")
-
-    case RTSP.play(rtsp_session) do
-      {:ok, %{status: 200}} -> {:ok, state}
-      _error -> {:error, :play_rtsp_failed, state}
-    end
-  end
-
-  defp play(%{rtsp_session: rtsp_session, transport: :tcp} = state) do
-    Membrane.Logger.debug("ConnectionManager: Setting RTSP on play mode")
-
-    RTSP.play_no_response(rtsp_session)
-    {:ok, state}
-  end
-
-  @spec keep_alive(State.t()) :: State.t()
-  defp keep_alive(state) do
-    Membrane.Logger.debug("Send GET_PARAMETER to keep session alive")
-
-    case state.transport do
-      :tcp ->
-        RTSP.get_parameter_no_response(state.rtsp_session)
-
-      {:udp, _port_range_start, _port_range_end} ->
-        {:ok, %{status: 200}} = RTSP.get_parameter(state.rtsp_session)
-    end
-
-    %{state | keep_alive_timer: start_keep_alive_timer(state)}
   end
 
   @spec start_keep_alive_timer(State.t()) :: reference()
@@ -311,12 +222,6 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
     if state.rtsp_session != nil, do: RTSP.close(state.rtsp_session)
 
     raise "RTSP connection failed, reason: #{inspect(reason)}"
-  end
-
-  @spec notify_parent(term(), State.t()) :: State.t()
-  defp notify_parent(msg, state) do
-    send(state.parent_pid, msg)
-    state
   end
 
   @spec get_tracks(RTSP.Response.t(), media_types()) :: [track()]

--- a/test/membrane_rtsp_plugin/source/connection_manager_test.exs
+++ b/test/membrane_rtsp_plugin/source/connection_manager_test.exs
@@ -26,35 +26,18 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
   """
 
   setup do
-    opts = %{
+    state = %RTSP.Source.State{
       stream_uri: @stream_uri,
       allowed_media_types: @allowed_media_types,
       transport: :tcp,
       timeout: Membrane.Time.seconds(15),
-      keep_alive_interval: Membrane.Time.seconds(15),
-      parent_pid: self()
+      keep_alive_interval: Membrane.Time.seconds(15)
     }
 
-    %{opts: opts}
+    %{state: state}
   end
 
-  test "initialize state", %{opts: opts} do
-    assert {:ok,
-            %ConnectionManager.State{
-              stream_uri: @stream_uri,
-              allowed_media_types: @allowed_media_types,
-              transport: :tcp,
-              timeout: Membrane.Time.seconds(15),
-              keep_alive_interval: Membrane.Time.seconds(15),
-              rtsp_session: nil,
-              tracks: [],
-              keep_alive_timer: nil,
-              parent_pid: self()
-            }} ==
-             ConnectionManager.init(opts)
-  end
-
-  test "successful connection", %{opts: opts} do
+  test "successful connection", %{state: state} do
     pid = :c.pid(0, 1, 1)
 
     expect(RTSP.start_link(@stream_uri, _options), do: {:ok, pid})
@@ -66,17 +49,16 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
     expect(RTSP.setup(^pid, _control, _headers), [num_calls: 3], do: {:ok, Response.new(200)})
     expect(RTSP.get_socket(^pid), do: :socket)
 
-    assert {:ok, state} = ConnectionManager.init(opts)
+    assert state = ConnectionManager.initialize_connection(state)
 
-    assert {:noreply, state} = ConnectionManager.handle_info(:connect, state)
+    assert state = ConnectionManager.play(state)
     assert state.rtsp_session == pid
 
-    assert_received %{tracks: tracks}
-    assert length(tracks) == 3
-    assert [:application, :audio, :video] == Enum.map(tracks, & &1.type)
+    assert length(state.tracks) == 3
+    assert [:application, :audio, :video] == Enum.map(state.tracks, & &1.type)
   end
 
-  test "failed connection", %{opts: opts} do
+  test "failed connection", %{state: state} do
     pid = :c.pid(0, 1, 1)
 
     expect(RTSP.start_link(@stream_uri, _options), do: {:error, :econnrefused})
@@ -85,14 +67,12 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
     expect(RTSP.describe(^pid, [{"accept", "application/sdp"}]), do: {:ok, Response.new(401)})
     expect(RTSP.describe(^pid, [{"accept", "application/sdp"}]), do: {:ok, Response.new(404)})
 
-    assert {:ok, state} = ConnectionManager.init(opts)
-
     assert_raise RuntimeError,
                  "RTSP connection failed, reason: :econnrefused",
-                 fn -> ConnectionManager.handle_info(:connect, state) end
+                 fn -> ConnectionManager.initialize_connection(state) end
 
     assert_raise RuntimeError,
                  "RTSP connection failed, reason: :getting_rtsp_description_failed",
-                 fn -> ConnectionManager.handle_info(:connect, state) end
+                 fn -> ConnectionManager.initialize_connection(state) end
   end
 end

--- a/test/membrane_rtsp_plugin/source/connection_manager_test.exs
+++ b/test/membrane_rtsp_plugin/source/connection_manager_test.exs
@@ -49,7 +49,7 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
     expect(RTSP.setup(^pid, _control, _headers), [num_calls: 3], do: {:ok, Response.new(200)})
     expect(RTSP.get_socket(^pid), do: :socket)
 
-    assert state = ConnectionManager.initialize_connection(state)
+    assert state = ConnectionManager.establish_connection(state)
 
     assert state = ConnectionManager.play(state)
     assert state.rtsp_session == pid
@@ -69,10 +69,10 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
 
     assert_raise RuntimeError,
                  "RTSP connection failed, reason: :econnrefused",
-                 fn -> ConnectionManager.initialize_connection(state) end
+                 fn -> ConnectionManager.establish_connection(state) end
 
     assert_raise RuntimeError,
                  "RTSP connection failed, reason: :getting_rtsp_description_failed",
-                 fn -> ConnectionManager.initialize_connection(state) end
+                 fn -> ConnectionManager.establish_connection(state) end
   end
 end


### PR DESCRIPTION
closes https://github.com/membraneframework/membrane_core/issues/825

This PR changes ConnectionManager from a GenServer to a regular module, since the removal of retrying functionality made a dedicated process for managing the connection unnecessary. Now the Bin process takes care of establishing and maintaining the connection.