### PR TITLE
Monitor rtsp session

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following line to your deps in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:membrane_rtsp_plugin, "~> 0.5.0"}
+    {:membrane_rtsp_plugin, "~> 0.5.1"}
   ]
 end
 ```

--- a/lib/membrane_rtsp_plugin/source.ex
+++ b/lib/membrane_rtsp_plugin/source.ex
@@ -130,8 +130,8 @@ defmodule Membrane.RTSP.Source do
   end
 
   @impl true
-  def handle_setup(_ctx, state) do
-    state = ConnectionManager.establish_connection(state)
+  def handle_setup(ctx, state) do
+    state = ConnectionManager.establish_connection(ctx.utility_supervisor, state)
 
     {[spec: create_sources_spec(state), notify_parent: get_set_up_tracks_notification(state)],
      state}

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -69,11 +69,11 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
 
   @spec start_rtsp_connection(State.t()) :: connection_establishment_phase_return()
   defp start_rtsp_connection(state) do
-    case RTSP.start_link(state.stream_uri,
+    case RTSP.start(state.stream_uri,
            response_timeout: Membrane.Time.as_milliseconds(state.timeout, :round)
          ) do
       {:ok, session} ->
-        Process.flag(:trap_exit, true)
+        Process.monitor(session)
         {:ok, %{state | rtsp_session: session}}
 
       {:error, reason} ->

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -31,10 +31,10 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
     RTSP.transfer_socket_control(rtsp_session, new_controller)
   end
 
-  @spec establish_connection(State.t()) :: State.t()
-  def establish_connection(state) do
+  @spec establish_connection(Membrane.UtilitySupervisor.t(), State.t()) :: State.t()
+  def establish_connection(utility_supervisor, state) do
     state =
-      with {:ok, state} <- start_rtsp_connection(state),
+      with {:ok, state} <- start_rtsp_connection(utility_supervisor, state),
            {:ok, state} <- get_rtsp_description(state),
            {:ok, state} <- setup_rtsp_connection(state) do
         state
@@ -67,11 +67,20 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
     %{state | keep_alive_timer: start_keep_alive_timer(state)}
   end
 
-  @spec start_rtsp_connection(State.t()) :: connection_establishment_phase_return()
-  defp start_rtsp_connection(state) do
-    case RTSP.start(state.stream_uri,
-           response_timeout: Membrane.Time.as_milliseconds(state.timeout, :round)
-         ) do
+  @spec start_rtsp_connection(Membrane.UtilitySupervisor.t(), State.t()) ::
+          connection_establishment_phase_return()
+  defp start_rtsp_connection(utility_supervisor, state) do
+    rtsp_session_child_spec = %{
+      id: RTSP,
+      start:
+        {RTSP, :start_link,
+         [
+           state.stream_uri,
+           [response_timeout: Membrane.Time.as_milliseconds(state.timeout, :round)]
+         ]}
+    }
+
+    case Membrane.UtilitySupervisor.start_child(utility_supervisor, rtsp_session_child_spec) do
       {:ok, session} ->
         Process.monitor(session)
         {:ok, %{state | rtsp_session: session}}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTSP.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
   @github_url "https://github.com/gBillal/membrane_rtsp_plugin"
 
   def project do

--- a/test/membrane_rtsp_plugin/source/connection_manager_test.exs
+++ b/test/membrane_rtsp_plugin/source/connection_manager_test.exs
@@ -41,7 +41,7 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
   test "successful connection", %{state: state} do
     pid = :c.pid(0, 1, 1)
 
-    expect(RTSP.start_link(@stream_uri, _options), do: {:ok, pid})
+    expect(RTSP.start(@stream_uri, _options), do: {:ok, pid})
 
     expect RTSP.describe(^pid, [{"accept", "application/sdp"}]) do
       {:ok, %Response{Response.new(200) | body: ExSDP.parse!(@sdp)}}
@@ -63,8 +63,8 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
   test "failed connection", %{state: state} do
     pid = :c.pid(0, 1, 1)
 
-    expect(RTSP.start_link(@stream_uri, _options), do: {:error, :econnrefused})
-    expect(RTSP.start_link(@stream_uri, _options), do: {:ok, pid})
+    expect(RTSP.start(@stream_uri, _options), do: {:error, :econnrefused})
+    expect(RTSP.start(@stream_uri, _options), do: {:ok, pid})
 
     expect(RTSP.describe(^pid, [{"accept", "application/sdp"}]), do: {:ok, Response.new(404)})
 

--- a/test/membrane_rtsp_plugin/source/connection_manager_test.exs
+++ b/test/membrane_rtsp_plugin/source/connection_manager_test.exs
@@ -40,8 +40,14 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
 
   test "successful connection", %{state: state} do
     pid = :c.pid(0, 1, 1)
+    {:ok, supervisor} = Supervisor.start_link([], strategy: :one_for_one)
 
     expect(RTSP.start(@stream_uri, _options), do: {:ok, pid})
+
+    expect(
+      Membrane.UtilitySupervisor.start_child(_sup, %{start: {RTSP, :start_link, [uri, options]}}),
+      do: RTSP.start(uri, options)
+    )
 
     expect RTSP.describe(^pid, [{"accept", "application/sdp"}]) do
       {:ok, %Response{Response.new(200) | body: ExSDP.parse!(@sdp)}}
@@ -51,7 +57,7 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
     expect(RTSP.get_socket(^pid), do: :socket)
     expect(RTSP.play(^pid), do: {:ok, Response.new(200)})
 
-    assert state = ConnectionManager.establish_connection(state)
+    assert state = ConnectionManager.establish_connection(supervisor, state)
 
     assert state = ConnectionManager.play(state)
     assert state.rtsp_session == pid
@@ -62,6 +68,13 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
 
   test "failed connection", %{state: state} do
     pid = :c.pid(0, 1, 1)
+    {:ok, supervisor} = Supervisor.start_link([], strategy: :one_for_one)
+
+    expect(
+      Membrane.UtilitySupervisor.start_child(_sup, %{start: {RTSP, :start_link, [uri, options]}}),
+      [num_calls: 2],
+      do: RTSP.start(uri, options)
+    )
 
     expect(RTSP.start(@stream_uri, _options), do: {:error, :econnrefused})
     expect(RTSP.start(@stream_uri, _options), do: {:ok, pid})
@@ -70,10 +83,10 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
 
     assert_raise RuntimeError,
                  "RTSP connection failed, reason: :econnrefused",
-                 fn -> ConnectionManager.establish_connection(state) end
+                 fn -> ConnectionManager.establish_connection(supervisor, state) end
 
     assert_raise RuntimeError,
                  "RTSP connection failed, reason: :getting_rtsp_description_failed",
-                 fn -> ConnectionManager.establish_connection(state) end
+                 fn -> ConnectionManager.establish_connection(supervisor, state) end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 Mimic.copy(Membrane.RTSP)
+Mimic.copy(Membrane.UtilitySupervisor)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
Previously the Source bin detected the connection being severed by linking with the session process and trapping exits. This solution proved problematic, as the Source would trap all exits, not just the relevant ones from the session. The RTSP session process will now be started under UtilitySupervisor and monitored, solving the problem.