### PR TITLE
Expose SDP framerate attribute on track in Source

### DIFF
--- a/lib/membrane_rtsp_plugin/source.ex
+++ b/lib/membrane_rtsp_plugin/source.ex
@@ -32,6 +32,7 @@ defmodule Membrane.RTSP.Source do
   @type track :: %{
           control_path: String.t(),
           type: :video | :audio | :application,
+          framerate: ExSDP.Attribute.framerate_value() | nil,
           fmtp: ExSDP.Attribute.FMTP.t() | nil,
           rtpmap: ExSDP.Attribute.RTPMapping.t() | nil
         }

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -18,6 +18,7 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
   @type track :: %{
           control_path: String.t(),
           type: :video | :audio | :application,
+          framerate: ExSDP.Attribute.framerate_value() | nil,
           fmtp: ExSDP.Attribute.FMTP.t() | nil,
           rtpmap: ExSDP.Attribute.RTPMapping.t() | nil,
           transport: track_transport()
@@ -225,6 +226,7 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
     |> Enum.map(fn media ->
       %{
         control_path: get_attribute(media, "control", ""),
+        framerate: get_attribute(media, :framerate, nil),
         type: media.type,
         rtpmap: get_attribute(media, ExSDP.Attribute.RTPMapping),
         fmtp: get_attribute(media, ExSDP.Attribute.FMTP),

--- a/test/membrane_rtsp_plugin/source/connection_manager_test.exs
+++ b/test/membrane_rtsp_plugin/source/connection_manager_test.exs
@@ -15,6 +15,7 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
   t=0 0
   m=video 0 RTP/AVP 96
   a=rtpmap:96 H264/90000
+  a=framerate:30
   a=fmtp:96 profile-level-id=42e01f;packetization-mode=1
   a=control:/video
   m=audio 0 RTP/AVP 97
@@ -64,6 +65,7 @@ defmodule Membrane.RTSP.Source.ConnectionManagerTest do
 
     assert length(state.tracks) == 3
     assert [:application, :audio, :video] == Enum.map(state.tracks, & &1.type)
+    assert [nil, nil, 30.0] == Enum.map(state.tracks, & &1.framerate)
   end
 
   test "failed connection", %{state: state} do


### PR DESCRIPTION
Exposes the `:framerate` SDP attribute on the track in `ConnectionManager` (and `Source`)

Maybe better to expose attributes generally, but I need the framerate, so adding the bare minimum now. Let me know if there's a better approach, I'm very infant in this space currently.