### PR TITLE
Use RTP demuxer, change notification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following line to your deps in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:membrane_rtsp_plugin, "~> 0.6.1"}
+    {:membrane_rtsp_plugin, "~> 0.7.0"}
   ]
 end
 ```
@@ -45,26 +45,19 @@ defmodule RtspPipeline do
   end
 
   @impl true
-  def handle_child_notification({:new_track, ssrc, _track}, _element, _ctx, state) do
-    spec = [
-      get_child(:source)
-      |> via_out(Pad.ref(:output, ssrc))
-      |> child(:funnel, Membrane.Funnel)
-      |> child(:sink, , %Membrane.File.Source{
-        location: "video.h264"
-      })
-    ]
+  def handle_child_notification({:set_up_tracks, tracks}, _element, _ctx, state) do
+    spec =
+      Enum.map(track, fn track ->
+        get_child(:source)
+        |> via_out(Pad.ref(:output, track.control_path))
+        |> child(:sink, %Membrane.File.Source{location: "video.h264"})
+      end)
 
     {[spec: spec], state}
   end
 
   @impl true
   def handle_child_notification(_message, _element, _ctx, state) do
-    {[], state}
-  end
-
-  @impl true
-  def handle_child_pad_removed(:source, _pad, _ctx, state) do
     {[], state}
   end
 end

--- a/lib/membrane_rtsp_plugin/source.ex
+++ b/lib/membrane_rtsp_plugin/source.ex
@@ -2,7 +2,7 @@ defmodule Membrane.RTSP.Source do
   @moduledoc """
   Source bin responsible for connecting to an RTSP server.
 
-  This element connects to an RTSP server, depayload and parses the received media if possible.
+  This element connects to an RTSP server, depayloads and parses the received media if possible.
   If there's no suitable depayloader and parser, the raw payload is sent to the subsequent elements in
   the pipeline.
 
@@ -15,9 +15,8 @@ defmodule Membrane.RTSP.Source do
     * `Opus`
 
   When the element finishes setting up all tracks it will send a `t:set_up_tracks/0` notification.
-  Each time a track is parsed and available for further processing the element will send a
-  `t:new_track/0` notification. An output pad `Pad.ref(:output, ssrc)` should be linked to receive
-  the data.
+  To receive a track a corresponding `Pad.ref(:output, control_path)` pad has to be connected,
+  where each track's control path is provided in the `t:set_up_tracks/0` notification.
   """
 
   use Membrane.Bin

--- a/lib/membrane_rtsp_plugin/source/connection_manager.ex
+++ b/lib/membrane_rtsp_plugin/source/connection_manager.ex
@@ -52,7 +52,7 @@ defmodule Membrane.RTSP.Source.ConnectionManager do
 
     case RTSP.play(state.rtsp_session) do
       {:ok, %{status: 200}} ->
-        %{state | keep_alive_timer: start_keep_alive_timer(state)}
+        %{state | keep_alive_timer: start_keep_alive_timer(state), play_request_sent: true}
 
       _error ->
         handle_rtsp_error(:play_rtsp_failed, state)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTSP.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.6.1"
+  @version "0.7.0"
   @github_url "https://github.com/gBillal/membrane_rtsp_plugin"
 
   def project do


### PR DESCRIPTION
This PR replaces RTP.SessionBin with RTP.Demuxers, elements that take in a single RTP stream, demuxes and depayloads it into a single or multiple media streams. Due to that, when using UDP transport, each incoming stream will have it's own demuxer. 

This allows us to simplify the notification API. Up until now the element sent `set_up_tracks` and `new_rtp_stream` notifications. From now on the element would send only `set_up_tracks` notification and the parent could connect all pads based on control paths provided in the notification instead of relying on ssrcs.

For example, when the source finishes the `SETUP` phase it sends the `set_up_tracks` notification containing information about all tracks that have been set up. The parent can now connect a pad for each set up track upfront, with `Pad.ref(:output, <track_control_path>)`, instead of waiting for the `new_rtp_stream` notifications.